### PR TITLE
Windows fixes

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -113,8 +113,10 @@ string GameWindow::SDLVersions()
 bool GameWindow::Init(bool headless)
 {
 #ifdef _WIN32
+#ifndef ES_USE_SDL3
 	// Tell Windows this process is high dpi aware and doesn't need to get scaled.
 	SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
+#endif
 #elif defined(__linux__)
 	// Set the class name for the window on Linux. Used to set the application icon.
 	// This sets it for both X11 and Wayland.

--- a/source/SDL.h
+++ b/source/SDL.h
@@ -30,6 +30,9 @@ using mouse_pos_t = float;
 #ifndef SDL_HINT_VIDEODRIVER
 #define SDL_HINT_VIDEODRIVER SDL_HINT_VIDEO_DRIVER
 #endif
+#ifndef SDL_HINT_WINDOWS_DPI_AWARENESS
+#define SDL_HINT_WINDOWS_DPI_AWARENESS "SDL_WINDOWS_DPI_AWARENESS"
+#endif
 
 // These are defined to warn you about small api changes, not relevant for us
 #ifdef SDL_WINDOW_FULLSCREEN_DESKTOP

--- a/source/SDL.h
+++ b/source/SDL.h
@@ -30,9 +30,6 @@ using mouse_pos_t = float;
 #ifndef SDL_HINT_VIDEODRIVER
 #define SDL_HINT_VIDEODRIVER SDL_HINT_VIDEO_DRIVER
 #endif
-#ifndef SDL_HINT_WINDOWS_DPI_AWARENESS
-#define SDL_HINT_WINDOWS_DPI_AWARENESS "SDL_WINDOWS_DPI_AWARENESS"
-#endif
 
 // These are defined to warn you about small api changes, not relevant for us
 #ifdef SDL_WINDOW_FULLSCREEN_DESKTOP

--- a/source/windows/WinWindow.cpp
+++ b/source/windows/WinWindow.cpp
@@ -19,7 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "WinVersion.h"
 
 #ifdef ES_USE_SDL3
-#include "SDL.h"
+#include "../SDL.h"
 #else
 #include <SDL2/SDL_syswm.h>
 #endif

--- a/source/windows/WinWindow.cpp
+++ b/source/windows/WinWindow.cpp
@@ -19,7 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "WinVersion.h"
 
 #ifdef ES_USE_SDL3
-#include <SDL3/SDL.h>
+#include "SDL.h"
 #else
 #include <SDL2/SDL_syswm.h>
 #endif

--- a/source/windows/WinWindow.cpp
+++ b/source/windows/WinWindow.cpp
@@ -19,7 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "WinVersion.h"
 
 #ifdef ES_USE_SDL3
-#include <SDL3/SDL_syswm.h>
+#include <SDL3/SDL.h>
 #else
 #include <SDL2/SDL_syswm.h>
 #endif
@@ -33,9 +33,15 @@ void WinWindow::UpdateTitleBarTheme(SDL_Window *window)
 	if(!WinVersion::SupportsDarkTheme())
 		return;
 
+#ifdef ES_USE_SDL3
+	HWND hwnd = reinterpret_cast<HWND>(SDL_GetPointerProperty(SDL_GetWindowProperties(window),
+		SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL));
+#else
 	SDL_SysWMinfo windowInfo;
 	SDL_VERSION(&windowInfo.version);
 	SDL_GetWindowWMInfo(window, &windowInfo);
+	HWND hwnd = windowInfo.info.win.window;
+#endif
 
 	BOOL value;
 	Preferences::TitleBarTheme themePreference = Preferences::GetTitleBarTheme();
@@ -64,7 +70,7 @@ void WinWindow::UpdateTitleBarTheme(SDL_Window *window)
 	HMODULE dwmapi = LoadLibraryW(L"dwmapi.dll");
 	auto dwmSetWindowAttribute = reinterpret_cast<HRESULT (*)(HWND, DWORD, LPCVOID, DWORD)>(
 		GetProcAddress(dwmapi, "DwmSetWindowAttribute"));
-	dwmSetWindowAttribute(windowInfo.info.win.window, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
+	dwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
 	FreeLibrary(dwmapi);
 }
 
@@ -75,15 +81,21 @@ void WinWindow::UpdateWindowRounding(SDL_Window *window)
 	if(!WinVersion::SupportsWindowRounding())
 		return;
 
+#ifdef ES_USE_SDL3
+	HWND hwnd = reinterpret_cast<HWND>(SDL_GetPointerProperty(SDL_GetWindowProperties(window),
+		SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL));
+#else
 	SDL_SysWMinfo windowInfo;
 	SDL_VERSION(&windowInfo.version);
 	SDL_GetWindowWMInfo(window, &windowInfo);
+	HWND hwnd = windowInfo.info.win.window;
+#endif
 
 	auto value = static_cast<DWM_WINDOW_CORNER_PREFERENCE>(Preferences::GetWindowRounding());
 
 	HMODULE dwmapi = LoadLibraryW(L"dwmapi.dll");
 	auto dwmSetWindowAttribute = reinterpret_cast<HRESULT (*)(HWND, DWORD, LPCVOID, DWORD)>(
 		GetProcAddress(dwmapi, "DwmSetWindowAttribute"));
-	dwmSetWindowAttribute(windowInfo.info.win.window, DWMWA_WINDOW_CORNER_PREFERENCE, &value, sizeof(value));
+	dwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &value, sizeof(value));
 	FreeLibrary(dwmapi);
 }


### PR DESCRIPTION
@tibetiroka 

I was going to test the SDL3 branch on Windows, but I've run into some build problems.

For some reason the SDL3 source doesn't have the SDL_HINT_WINDOWS_DPI_AWARENESS macro defined, even though the migration wiki page doesn't mention this one. The only result that shows up on Github search of the SDL3 repo is [this](https://github.com/libsdl-org/SDL/blob/b181eb4ed0e117083e86b66e538492c815c8f899/src/video/windows/SDL_windowsvideo.c#L580) use, which happens to match the old value of the macro in SDL2, so apparently it still works.

The other change is the [documented](https://wiki.libsdl.org/SDL3/README-migration#sdl_syswmh) removal of SDL_syswm.h.